### PR TITLE
Update headers and callback for TakaraAI

### DIFF
--- a/src/activate/handleUri.ts
+++ b/src/activate/handleUri.ts
@@ -28,10 +28,10 @@ export const handleUri = async (uri: vscode.Uri) => {
 			}
 			break
 		}
-		case "/kilocode": {
+		case "/takaraai": {
 			const token = query.get("token")
 			if (token) {
-				await visibleProvider.handleKiloCodeCallback(token)
+				await visibleProvider.handleTakaraAICallback(token)
 			}
 			break
 		}

--- a/src/api/providers/__tests__/constants.spec.ts
+++ b/src/api/providers/__tests__/constants.spec.ts
@@ -12,16 +12,16 @@ describe("DEFAULT_HEADERS", () => {
 	})
 
 	it("should have correct HTTP-Referer value", () => {
-		expect(DEFAULT_HEADERS["HTTP-Referer"]).toBe("https://kilocode.ai")
+		expect(DEFAULT_HEADERS["HTTP-Referer"]).toBe("https://takara.ai")
 	})
 
 	it("should have correct X-Title value", () => {
-		expect(DEFAULT_HEADERS["X-Title"]).toBe("Kilo Code")
+		expect(DEFAULT_HEADERS["X-Title"]).toBe("TAKARA AI")
 	})
 
 	it("should have correct User-Agent format", () => {
 		const userAgent = DEFAULT_HEADERS["User-Agent"]
-		expect(userAgent).toBe(`Kilo-Code/${Package.version}`)
+		expect(userAgent).toBe(`TAKARA AI/${Package.version}`)
 
 		// Verify it follows the tool_name/version pattern
 		expect(userAgent).toMatch(/^[a-zA-Z-]+\/\d+\.\d+\.\d+$/)
@@ -29,7 +29,7 @@ describe("DEFAULT_HEADERS", () => {
 
 	it("should have User-Agent with correct tool name", () => {
 		const userAgent = DEFAULT_HEADERS["User-Agent"]
-		expect(userAgent.startsWith("Kilo-Code/")).toBe(true)
+		expect(userAgent.startsWith("TAKARA AI/")).toBe(true)
 	})
 
 	it("should have User-Agent with semantic version format", () => {
@@ -56,6 +56,6 @@ describe("DEFAULT_HEADERS", () => {
 	it("should have exactly 3 headers", () => {
 		const headerKeys = Object.keys(DEFAULT_HEADERS)
 		expect(headerKeys).toHaveLength(4)
-		expect(headerKeys).toEqual(["HTTP-Referer", "X-Title", "X-KiloCode-Version", "User-Agent"])
+		expect(headerKeys).toEqual(["HTTP-Referer", "X-Title", "X-TakaraAI-Version", "User-Agent"])
 	})
 })

--- a/src/api/providers/__tests__/openai.spec.ts
+++ b/src/api/providers/__tests__/openai.spec.ts
@@ -103,10 +103,10 @@ describe("OpenAiHandler", () => {
 				baseURL: expect.any(String),
 				apiKey: expect.any(String),
 				defaultHeaders: {
-					"HTTP-Referer": "https://kilocode.ai",
-					"X-Title": "Kilo Code",
-					"X-KiloCode-Version": Package.version,
-					"User-Agent": `Kilo-Code/${Package.version}`,
+					"HTTP-Referer": "https://takara.ai",
+					"X-Title": "TAKARA AI",
+					"X-TakaraAI-Version": Package.version,
+					"User-Agent": `TAKARA AI/${Package.version}`,
 				},
 			})
 		})

--- a/src/api/providers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/__tests__/openrouter.spec.ts
@@ -61,10 +61,10 @@ describe("OpenRouterHandler", () => {
 			baseURL: "https://openrouter.ai/api/v1",
 			apiKey: mockOptions.openRouterApiKey,
 			defaultHeaders: {
-				"HTTP-Referer": "https://kilocode.ai",
-				"X-Title": "Kilo Code",
-				"X-KiloCode-Version": Package.version,
-				"User-Agent": `Kilo-Code/${Package.version}`,
+				"HTTP-Referer": "https://takara.ai",
+				"X-Title": "TAKARA AI",
+				"X-TakaraAI-Version": Package.version,
+				"User-Agent": `TAKARA AI/${Package.version}`,
 			},
 		})
 	})

--- a/src/api/providers/__tests__/requesty.spec.ts
+++ b/src/api/providers/__tests__/requesty.spec.ts
@@ -58,10 +58,10 @@ describe("RequestyHandler", () => {
 			baseURL: "https://router.requesty.ai/v1",
 			apiKey: mockOptions.requestyApiKey,
 			defaultHeaders: {
-				"HTTP-Referer": "https://kilocode.ai",
-				"X-Title": "Kilo Code",
-				"X-KiloCode-Version": Package.version,
-				"User-Agent": `Kilo-Code/${Package.version}`,
+				"HTTP-Referer": "https://takara.ai",
+				"X-Title": "TAKARA AI",
+				"X-TakaraAI-Version": Package.version,
+				"User-Agent": `TAKARA AI/${Package.version}`,
 			},
 		})
 	})

--- a/src/api/providers/constants.ts
+++ b/src/api/providers/constants.ts
@@ -1,8 +1,8 @@
 import { Package } from "../../shared/package"
 
 export const DEFAULT_HEADERS = {
-	"HTTP-Referer": "https://kilocode.ai",
+	"HTTP-Referer": "https://takara.ai",
 	"X-Title": "TAKARA AI",
-	"X-KiloCode-Version": Package.version,
+	"X-TakaraAI-Version": Package.version,
 	"User-Agent": `TAKARA AI/${Package.version}`,
 }

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1031,14 +1031,14 @@ export class ClineProvider
 		// Get platform-specific application data directory
 		let mcpServersDir: string
 		if (process.platform === "win32") {
-			// Windows: %APPDATA%\Kilo-Code\MCP
-			mcpServersDir = path.join(os.homedir(), "AppData", "Roaming", "Kilo-Code", "MCP")
+			// Windows: %APPDATA%\Takara-AI\MCP
+			mcpServersDir = path.join(os.homedir(), "AppData", "Roaming", "Takara-AI", "MCP")
 		} else if (process.platform === "darwin") {
-			// macOS: ~/Documents/Kilo-Code/MCP
-			mcpServersDir = path.join(os.homedir(), "Documents", "Kilo-Code", "MCP")
+			// macOS: ~/Documents/Takara-AI/MCP
+			mcpServersDir = path.join(os.homedir(), "Documents", "Takara-AI", "MCP")
 		} else {
-			// Linux: ~/.local/share/Kilo-Code/MCP
-			mcpServersDir = path.join(os.homedir(), ".local", "share", "Kilo-Code", "MCP")
+			// Linux: ~/.local/share/Takara-AI/MCP
+			mcpServersDir = path.join(os.homedir(), ".local", "share", "Takara-AI", "MCP")
 		}
 
 		try {
@@ -1135,7 +1135,7 @@ export class ClineProvider
 	}
 
 	// kilocode_change:
-	async handleKiloCodeCallback(token: string) {
+	async handleTakaraAICallback(token: string) {
 		const kilocode: ProviderName = "kilocode"
 		let { apiConfiguration, currentApiConfigName } = await this.getState()
 


### PR DESCRIPTION
## Summary
- rename HTTP header to `X-TakaraAI-Version`
- update referer domain
- adjust TakaraAI OAuth callback path
- set default MCP directories to `Takara-AI`
- update related unit tests

## Testing
- `pnpm test` *(fails: @roo-code/cloud#test)*

------
https://chatgpt.com/codex/tasks/task_e_688ccd29b8748323bbf729d7f8039793