### PR TITLE
fix default provider profile for ghost model reload

### DIFF
--- a/src/services/ghost/GhostModel.ts
+++ b/src/services/ghost/GhostModel.ts
@@ -18,7 +18,7 @@ export class GhostModel {
 
 	public async reload(settings: GhostServiceSettings, providerSettingsManager: ProviderSettingsManager) {
 		this.apiConfigId = settings?.apiConfigId || null
-		const defaultApiConfigId = ContextProxy.instance?.getValues?.()?.currentApiConfigName || ""
+		const defaultApiConfigId = ContextProxy.instance?.getValues?.()?.currentApiConfigName || "default"
 
 		const profileQuery = this.apiConfigId
 			? {


### PR DESCRIPTION
## Summary
- default to `default` API profile when none configured to prevent activation errors

## Testing
- `pnpm --filter ./src test` *(fails: "Test Files 3 failed | 256 passed | 4 skipped (263)")*

------
https://chatgpt.com/codex/tasks/task_e_688dd9f308948323bac3fdf9d4154c1a