### PR TITLE
feat(types): add aws provider settings

### DIFF
--- a/packages/types/src/global-settings.ts
+++ b/packages/types/src/global-settings.ts
@@ -179,6 +179,11 @@ export const SECRET_STATE_KEYS = [
 	"codeIndexOpenAiKey",
 	"codeIndexQdrantApiKey",
 	"codebaseIndexOpenAiCompatibleApiKey",
+	// AWS Bedrock credentials
+	"awsApiKey",
+	"awsAccessKey",
+	"awsSecretKey",
+	"awsSessionToken",
 ] as const satisfies readonly (keyof ProviderSettings)[]
 export type SecretState = Pick<ProviderSettings, (typeof SECRET_STATE_KEYS)[number]>
 

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -42,6 +42,23 @@ const baseProviderSettingsSchema = z.object({
 	reasoningEffort: reasoningEffortsSchema.optional(),
 	modelMaxTokens: z.number().optional(),
 	modelMaxThinkingTokens: z.number().optional(),
+
+	// AWS Bedrock configuration
+	awsApiKey: z.string().optional(),
+	awsProfileName: z.string().optional(),
+	awsAccessKey: z.string().optional(),
+	awsSecretKey: z.string().optional(),
+	awsSessionToken: z.string().optional(),
+	awsRegion: z.string().optional(),
+	awsCrossRegion: z.boolean().optional(),
+	awsUsePromptCache: z.boolean().optional(),
+	awsCustomArn: z.string().optional(),
+	awsBedrockVpc: z
+		.object({
+			useCustomVpcEndpoint: z.boolean().optional(),
+			vpcEndpointUrl: z.string().optional(),
+		})
+		.optional(),
 })
 
 // Several of the providers share common model config properties.
@@ -68,7 +85,7 @@ const openAiNativeSchema = apiModelIdProviderModelSchema.extend({
 	openAiNativeBaseUrl: z.string().optional(),
 })
 
-const defaultSchema = z.object({
+const defaultSchema = baseProviderSettingsSchema.extend({
 	apiProvider: z.undefined(),
 })
 


### PR DESCRIPTION
## Summary
- support AWS Bedrock credentials in provider settings
- track AWS keys in secret state list

## Testing
- `pnpm lint --filter @roo-code/types`
- `pnpm test --filter @roo-code/types`
- `pnpm test --filter takara-ai` *(fails: Type '"anthropic"' is not assignable to type '"openai" | "openai-native" | undefined')*


------
https://chatgpt.com/codex/tasks/task_e_688de84bf978832390f58ce539b93a07